### PR TITLE
feat(analyzer): integrate notifier functionality from Haskell microservice

### DIFF
--- a/app/analyzer/internal/adapter/controller/cli/cli.go
+++ b/app/analyzer/internal/adapter/controller/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ss49919201/keeput/app/analyzer/internal/adapter/fetcher/hatena"
 	"github.com/ss49919201/keeput/app/analyzer/internal/adapter/fetcher/zenn"
 	"github.com/ss49919201/keeput/app/analyzer/internal/adapter/locker/cfworker"
+	"github.com/ss49919201/keeput/app/analyzer/internal/adapter/notifier/discord"
 	"github.com/ss49919201/keeput/app/analyzer/internal/adapter/printer/stdout"
 	"github.com/ss49919201/keeput/app/analyzer/internal/model"
 	usecaseport "github.com/ss49919201/keeput/app/analyzer/internal/port/usecase"
@@ -31,6 +32,7 @@ func Analyze(ctx context.Context) error {
 		stdout.PrintAnalysisReport,
 		cfworker.NewAcquire(),
 		cfworker.NewRelease(),
+		discord.NewNotify(),
 	)(ctx, &usecaseport.AnalyzeInput{})
 	if result.IsError() {
 		return result.Error()

--- a/app/analyzer/internal/adapter/notifier/discord/discord.go
+++ b/app/analyzer/internal/adapter/notifier/discord/discord.go
@@ -1,0 +1,62 @@
+package discord
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/samber/mo"
+	"github.com/ss49919201/keeput/app/analyzer/internal/port/notifier"
+)
+
+type reqBody struct {
+	Content string `json:"content"`
+}
+
+func loadDiscordWebhookURL() mo.Option[string] {
+	url := os.Getenv("DISCORD_WEBHOOK_URL")
+	if url == "" {
+		return mo.None[string]()
+	}
+	return mo.Some(url)
+}
+
+func createMessage(isGoalAchieved bool) string {
+	if isGoalAchieved {
+		return "目標達成です🎊よく頑張りました！"
+	}
+	return "目標未達です😢これから頑張りましょう！"
+}
+
+func NewNotify() notifier.Notify {
+	return func(req *notifier.NotificationRequest) mo.Result[struct{}] {
+		webhookURL := loadDiscordWebhookURL()
+		if webhookURL.IsAbsent() {
+			return mo.Err[struct{}](fmt.Errorf("discord webhook url is not set or empty"))
+		}
+
+		body := reqBody{
+			Content: createMessage(req.IsGoalAchieved),
+		}
+
+		jsonData, err := json.Marshal(body)
+		if err != nil {
+			return mo.Err[struct{}](fmt.Errorf("failed to marshal request body: %w", err))
+		}
+
+		resp, err := http.Post(webhookURL.MustGet(), "application/json", bytes.NewBuffer(jsonData))
+		if err != nil {
+			return mo.Err[struct{}](fmt.Errorf("failed to send request: %w", err))
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return mo.Err[struct{}](fmt.Errorf("failed to request with status code: %d", resp.StatusCode))
+		}
+
+		fmt.Println("success request")
+		return mo.Ok(struct{}{})
+	}
+}

--- a/app/analyzer/internal/adapter/notifier/discord/discord_test.go
+++ b/app/analyzer/internal/adapter/notifier/discord/discord_test.go
@@ -1,0 +1,142 @@
+package discord
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/ss49919201/keeput/app/analyzer/internal/port/notifier"
+)
+
+func TestCreateMessage(t *testing.T) {
+	tests := []struct {
+		name           string
+		isGoalAchieved bool
+		expected       string
+	}{
+		{
+			name:           "goal achieved",
+			isGoalAchieved: true,
+			expected:       "目標達成です🎊よく頑張りました！",
+		},
+		{
+			name:           "goal not achieved",
+			isGoalAchieved: false,
+			expected:       "目標未達です😢これから頑張りましょう！",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := createMessage(tt.isGoalAchieved)
+			if result != tt.expected {
+				t.Errorf("createMessage() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLoadDiscordWebhookURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		hasValue bool
+	}{
+		{
+			name:     "url is set",
+			envValue: "https://discord.com/api/webhooks/123/456",
+			hasValue: true,
+		},
+		{
+			name:     "url is empty",
+			envValue: "",
+			hasValue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup environment
+			os.Setenv("DISCORD_WEBHOOK_URL", tt.envValue)
+			defer os.Unsetenv("DISCORD_WEBHOOK_URL")
+
+			result := loadDiscordWebhookURL()
+			if result.IsPresent() != tt.hasValue {
+				t.Errorf("loadDiscordWebhookURL() presence = %v, want %v", result.IsPresent(), tt.hasValue)
+			}
+
+			if tt.hasValue && result.MustGet() != tt.envValue {
+				t.Errorf("loadDiscordWebhookURL() = %v, want %v", result.MustGet(), tt.envValue)
+			}
+		})
+	}
+}
+
+func TestNewNotify(t *testing.T) {
+	tests := []struct {
+		name           string
+		webhookURL     string
+		isGoalAchieved bool
+		statusCode     int
+		expectError    bool
+	}{
+		{
+			name:           "successful notification - goal achieved",
+			webhookURL:     "valid",
+			isGoalAchieved: true,
+			statusCode:     200,
+			expectError:    false,
+		},
+		{
+			name:           "successful notification - goal not achieved",
+			webhookURL:     "valid",
+			isGoalAchieved: false,
+			statusCode:     200,
+			expectError:    false,
+		},
+		{
+			name:           "failed request - bad status code",
+			webhookURL:     "valid",
+			isGoalAchieved: true,
+			statusCode:     400,
+			expectError:    true,
+		},
+		{
+			name:           "missing webhook url",
+			webhookURL:     "",
+			isGoalAchieved: true,
+			statusCode:     200,
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup mock server
+			var server *httptest.Server
+			if tt.webhookURL == "valid" {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tt.statusCode)
+				}))
+				defer server.Close()
+				os.Setenv("DISCORD_WEBHOOK_URL", server.URL)
+			} else {
+				os.Setenv("DISCORD_WEBHOOK_URL", tt.webhookURL)
+			}
+			defer os.Unsetenv("DISCORD_WEBHOOK_URL")
+
+			notify := NewNotify()
+			result := notify(&notifier.NotificationRequest{
+				IsGoalAchieved: tt.isGoalAchieved,
+			})
+
+			if tt.expectError && result.IsOk() {
+				t.Error("expected error but got success")
+			}
+			if !tt.expectError && result.IsError() {
+				t.Errorf("expected success but got error: %v", result.Error())
+			}
+		})
+	}
+}

--- a/app/analyzer/internal/port/notifier/notifier.go
+++ b/app/analyzer/internal/port/notifier/notifier.go
@@ -1,0 +1,11 @@
+package notifier
+
+import (
+	"github.com/samber/mo"
+)
+
+type NotificationRequest struct {
+	IsGoalAchieved bool `json:"is_goal_achieved"`
+}
+
+type Notify = func(*NotificationRequest) mo.Result[struct{}]


### PR DESCRIPTION
Claude Code による実装。
モデルは Claude Sonnet4。
プロンプトは以下の通り。

```
あなたは熟練したソフトウェアエンジニアです。
以下のタスクを行ってください。

# タスク概要
既存の Haskell 製マイクロサービス（約 100 行）を、既存の Go 製マイクロサービス（約 1000 行）の内部機能へ移行してください。
移行対象コードは「移行前アプリケーション」と呼び、統合先を「移行後アプリケーション」と呼びます。

# 要件
 1. 機能保持: 移行前アプリケーションのビジネスロジック・API 振る舞いを Go 実装に正確に再現してください。
 2. Go の慣習順守: Go の標準的な命名規則・エラーハンドリング・構造体設計を採用してください。
 3. 統合場所: 移行後アプリケーションの既存アーキテクチャに適切に組み込んでください（例: `internal/` 以下にパッケージ追加、サービスレイヤーに統合など）。
 4. 型・エラーハンドリング: Haskell の強力な型システムや `Either`/`Maybe` を、Go では `error` 型や `struct` による表現に落とし込んでください。
 5. テスト: 移行前アプリケーションのテストケースを参考に、Go の `testing` パッケージでユニットテストを書いてください。
 
# アプリケーションコード
- 移行前アプリケーション: ./app/notifier
- 移行後アプリケーション: ./app/analyzer
```