### PR TITLE
feat(analyzer/notifier): Haskell製 notifier を Go に移管し Discord 通知を統合

### DIFF
--- a/app/analyzer/internal/adapter/controller/cli/cli.go
+++ b/app/analyzer/internal/adapter/controller/cli/cli.go
@@ -1,16 +1,17 @@
 package cli
 
 import (
-	"context"
+    "context"
 
-	"github.com/samber/lo"
-	"github.com/ss49919201/keeput/app/analyzer/internal/adapter/fetcher/hatena"
-	"github.com/ss49919201/keeput/app/analyzer/internal/adapter/fetcher/zenn"
-	"github.com/ss49919201/keeput/app/analyzer/internal/adapter/locker/cfworker"
-	"github.com/ss49919201/keeput/app/analyzer/internal/adapter/printer/stdout"
-	"github.com/ss49919201/keeput/app/analyzer/internal/model"
-	usecaseport "github.com/ss49919201/keeput/app/analyzer/internal/port/usecase"
-	usecaseadapter "github.com/ss49919201/keeput/app/analyzer/internal/usecase"
+    "github.com/samber/lo"
+    "github.com/ss49919201/keeput/app/analyzer/internal/adapter/fetcher/hatena"
+    "github.com/ss49919201/keeput/app/analyzer/internal/adapter/fetcher/zenn"
+    "github.com/ss49919201/keeput/app/analyzer/internal/adapter/locker/cfworker"
+    "github.com/ss49919201/keeput/app/analyzer/internal/adapter/notifier/discord"
+    "github.com/ss49919201/keeput/app/analyzer/internal/adapter/printer/stdout"
+    "github.com/ss49919201/keeput/app/analyzer/internal/model"
+    usecaseport "github.com/ss49919201/keeput/app/analyzer/internal/port/usecase"
+    usecaseadapter "github.com/ss49919201/keeput/app/analyzer/internal/usecase"
 )
 
 func Analyze(ctx context.Context) error {
@@ -26,12 +27,13 @@ func Analyze(ctx context.Context) error {
 		entryPlatformType == model.EntryPlatformTypeZenn, zenn.NewFetchLatest(),
 	).Else(hatena.NewFetchLatest())
 
-	result := usecaseadapter.NewAnalyze(
-		fetcher,
-		stdout.PrintAnalysisReport,
-		cfworker.NewAcquire(),
-		cfworker.NewRelease(),
-	)(ctx, &usecaseport.AnalyzeInput{})
+    result := usecaseadapter.NewAnalyze(
+        fetcher,
+        stdout.PrintAnalysisReport,
+        discord.NewNotifyByIsGoalAchieved(),
+        cfworker.NewAcquire(),
+        cfworker.NewRelease(),
+    )(ctx, &usecaseport.AnalyzeInput{})
 	if result.IsError() {
 		return result.Error()
 	}

--- a/app/analyzer/internal/adapter/notifier/discord/discord.go
+++ b/app/analyzer/internal/adapter/notifier/discord/discord.go
@@ -1,0 +1,65 @@
+package discord
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "errors"
+    "fmt"
+    "io"
+    "net/http"
+
+    "github.com/ss49919201/keeput/app/analyzer/internal/config"
+    "github.com/ss49919201/keeput/app/analyzer/internal/port/notifier"
+)
+
+type reqBody struct {
+    Content string `json:"content"`
+}
+
+// NewNotifyByIsGoalAchieved creates a notifier that posts to a Discord webhook
+// configured via the DISCORD_WEBHOOK_URL environment variable.
+func NewNotifyByIsGoalAchieved() notifier.NotifyByIsGoalAchieved {
+    return func(ctx context.Context, isGoalAchieved bool) error {
+        return notify(ctx, config.DiscordWebhookURL(), isGoalAchieved)
+    }
+}
+
+func notify(ctx context.Context, webhookURL string, isGoalAchieved bool) error {
+    if webhookURL == "" {
+        return errors.New("discord webhook url is not set or empty")
+    }
+
+    body := reqBody{Content: message(isGoalAchieved)}
+    payload, err := json.Marshal(body)
+    if err != nil {
+        return fmt.Errorf("failed to marshal request body: %w", err)
+    }
+
+    req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(payload))
+    if err != nil {
+        return fmt.Errorf("failed to create request: %w", err)
+    }
+    req.Header.Set("Content-Type", "application/json")
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        return fmt.Errorf("failed to request: %w", err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        b, _ := io.ReadAll(resp.Body)
+        return fmt.Errorf("failed to request with status code: %d; body: %s", resp.StatusCode, string(b))
+    }
+
+    return nil
+}
+
+func message(isGoalAchieved bool) string {
+    if isGoalAchieved {
+        return "目標達成です🎊よく頑張りました！"
+    }
+    return "目標未達です😢これから頑張りましょう！"
+}
+

--- a/app/analyzer/internal/adapter/notifier/discord/discord_test.go
+++ b/app/analyzer/internal/adapter/notifier/discord/discord_test.go
@@ -1,0 +1,72 @@
+package discord
+
+import (
+    "context"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+type payload struct {
+    Content string `json:"content"`
+}
+
+func TestNotify_Success_OnAchieved(t *testing.T) {
+    var received payload
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        defer r.Body.Close()
+        if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+            t.Fatalf("failed to decode: %v", err)
+        }
+        w.WriteHeader(http.StatusOK)
+    }))
+    t.Cleanup(ts.Close)
+
+    err := notify(context.Background(), ts.URL, true)
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if received.Content == "" {
+        t.Fatalf("expected content, got empty")
+    }
+}
+
+func TestNotify_Success_OnNotAchieved(t *testing.T) {
+    var received payload
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        defer r.Body.Close()
+        if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+            t.Fatalf("failed to decode: %v", err)
+        }
+        w.WriteHeader(http.StatusOK)
+    }))
+    t.Cleanup(ts.Close)
+
+    err := notify(context.Background(), ts.URL, false)
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if received.Content == "" {
+        t.Fatalf("expected content, got empty")
+    }
+}
+
+func TestNotify_ErrorWhenWebhookMissing(t *testing.T) {
+    if err := notify(context.Background(), "", true); err == nil {
+        t.Fatalf("expected error for missing webhook url")
+    }
+}
+
+func TestNotify_ErrorOnNon200(t *testing.T) {
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusBadRequest)
+        _, _ = w.Write([]byte(`{"error":"bad"}`))
+    }))
+    t.Cleanup(ts.Close)
+
+    if err := notify(context.Background(), ts.URL, true); err == nil {
+        t.Fatalf("expected error on non-200 response")
+    }
+}
+

--- a/app/analyzer/internal/config/config.go
+++ b/app/analyzer/internal/config/config.go
@@ -34,5 +34,13 @@ var lockerURLCloudflareWorker = sync.OnceValue(func() string {
 })
 
 func LockerURLCloudflareWorker() string {
-	return lockerURLCloudflareWorker()
+    return lockerURLCloudflareWorker()
+}
+
+var discordWebhookURL = sync.OnceValue(func() string {
+    return os.Getenv("DISCORD_WEBHOOK_URL")
+})
+
+func DiscordWebhookURL() string {
+    return discordWebhookURL()
 }

--- a/app/analyzer/internal/port/notifier/notifier.go
+++ b/app/analyzer/internal/port/notifier/notifier.go
@@ -1,0 +1,8 @@
+package notifier
+
+import "context"
+
+// NotifyByIsGoalAchieved sends a notification based on goal achievement.
+// true -> success message, false -> failure message.
+type NotifyByIsGoalAchieved = func(context.Context, bool) error
+

--- a/app/analyzer/internal/usecase/analyze_test.go
+++ b/app/analyzer/internal/usecase/analyze_test.go
@@ -1,26 +1,28 @@
 package usecase
 
 import (
-	"context"
-	"testing"
-	"time"
+    "context"
+    "testing"
+    "time"
 
-	"github.com/samber/mo"
-	"github.com/ss49919201/keeput/app/analyzer/internal/appctx"
-	"github.com/ss49919201/keeput/app/analyzer/internal/model"
-	"github.com/ss49919201/keeput/app/analyzer/internal/port/fetcher"
-	"github.com/ss49919201/keeput/app/analyzer/internal/port/locker"
-	"github.com/ss49919201/keeput/app/analyzer/internal/port/printer"
-	"github.com/ss49919201/keeput/app/analyzer/internal/port/usecase"
-	"github.com/stretchr/testify/assert"
+    "github.com/samber/mo"
+    "github.com/ss49919201/keeput/app/analyzer/internal/appctx"
+    "github.com/ss49919201/keeput/app/analyzer/internal/model"
+    "github.com/ss49919201/keeput/app/analyzer/internal/port/fetcher"
+    "github.com/ss49919201/keeput/app/analyzer/internal/port/locker"
+    "github.com/ss49919201/keeput/app/analyzer/internal/port/notifier"
+    "github.com/ss49919201/keeput/app/analyzer/internal/port/printer"
+    "github.com/ss49919201/keeput/app/analyzer/internal/port/usecase"
+    "github.com/stretchr/testify/assert"
 )
 
 func TestAnalyze(t *testing.T) {
-	type args struct {
-		NewFetchLatest         func(t *testing.T) fetcher.FetchLatest
-		NewPrintAnalysisReport func(t *testing.T) printer.PrintAnalysisReport
-		NewAcquireLock         func(t *testing.T) locker.Acquire
-		NewReleaseLock         func(t *testing.T) locker.Release
+    type args struct {
+        NewFetchLatest         func(t *testing.T) fetcher.FetchLatest
+        NewPrintAnalysisReport func(t *testing.T) printer.PrintAnalysisReport
+        NewNotify              func(t *testing.T) notifier.NotifyByIsGoalAchieved
+        NewAcquireLock         func(t *testing.T) locker.Acquire
+        NewReleaseLock         func(t *testing.T) locker.Release
 
 		ctx   context.Context
 		input *usecase.AnalyzeInput
@@ -30,104 +32,117 @@ func TestAnalyze(t *testing.T) {
 		args args
 		want mo.Result[*usecase.AnalyzeOutput]
 	}{
-		{
-			"return results of achieving goal",
-			args{
-				NewFetchLatest: func(t *testing.T) fetcher.FetchLatest {
-					return func(ctx context.Context) mo.Result[mo.Option[*model.Entry]] {
-						return mo.Ok(mo.Some(&model.Entry{
-							Title:       "Go 言語の slice について",
-							Body:        "Go 言語の slice は参照型です。気をつけましょう。",
-							PublishedAt: time.Date(2025, 1, 9, 10, 0, 0, 0, time.UTC),
-						}))
-					}
-				},
-				NewPrintAnalysisReport: func(t *testing.T) printer.PrintAnalysisReport {
-					return func(report *model.AnalysisReport) error {
-						assert.Equal(t, &model.AnalysisReport{
-							IsGoalAchieved: true,
-							LatestEntry: mo.Some(&model.Entry{
-								Title:       "Go 言語の slice について",
-								Body:        "Go 言語の slice は参照型です。気をつけましょう。",
-								PublishedAt: time.Date(2025, 1, 9, 10, 0, 0, 0, time.UTC),
-							}),
-						}, report)
+        {
+            "return results of achieving goal",
+            args{
+                NewFetchLatest: func(t *testing.T) fetcher.FetchLatest {
+                    return func(ctx context.Context) mo.Result[mo.Option[*model.Entry]] {
+                        return mo.Ok(mo.Some(&model.Entry{
+                            Title:       "Go 言語の slice について",
+                            Body:        "Go 言語の slice は参照型です。気をつけましょう。",
+                            PublishedAt: time.Date(2025, 1, 9, 10, 0, 0, 0, time.UTC),
+                        }))
+                    }
+                },
+                NewPrintAnalysisReport: func(t *testing.T) printer.PrintAnalysisReport {
+                    return func(report *model.AnalysisReport) error {
+                        assert.Equal(t, &model.AnalysisReport{
+                            IsGoalAchieved: true,
+                            LatestEntry: mo.Some(&model.Entry{
+                                Title:       "Go 言語の slice について",
+                                Body:        "Go 言語の slice は参照型です。気をつけましょう。",
+                                PublishedAt: time.Date(2025, 1, 9, 10, 0, 0, 0, time.UTC),
+                            }),
+                        }, report)
 
-						return nil
-					}
-				},
-				NewAcquireLock: func(t *testing.T) locker.Acquire {
-					return func(ctx context.Context, lockID string) mo.Result[bool] {
-						assert.Equal(t, "usecase:analyze:2025-01-10", lockID)
-						return mo.Ok(true)
-					}
-				},
-				NewReleaseLock: func(t *testing.T) locker.Release {
-					return func(ctx context.Context, lockID string) error {
-						assert.Equal(t, "usecase:analyze:2025-01-10", lockID)
-						return nil
-					}
-				},
-				ctx: appctx.SetNow(context.Background(), time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC)),
-				input: &usecase.AnalyzeInput{
-					Goal: model.GoalTypeRecentWeek,
-				},
-			},
-			mo.Ok(&usecase.AnalyzeOutput{
-				IsGoalAchieved: true,
-			}),
-		},
-		{
-			"return results of not achieving goal",
-			args{
-				NewFetchLatest: func(t *testing.T) fetcher.FetchLatest {
-					return func(ctx context.Context) mo.Result[mo.Option[*model.Entry]] {
-						return mo.Ok(mo.None[*model.Entry]())
-					}
-				},
-				NewPrintAnalysisReport: func(t *testing.T) printer.PrintAnalysisReport {
-					return func(report *model.AnalysisReport) error {
-						assert.Equal(t, &model.AnalysisReport{
-							IsGoalAchieved: false,
-							LatestEntry:    mo.None[*model.Entry](),
-						}, report)
+                        return nil
+                    }
+                },
+                NewNotify: func(t *testing.T) notifier.NotifyByIsGoalAchieved {
+                    return func(ctx context.Context, isGoalAchieved bool) error {
+                        assert.True(t, isGoalAchieved)
+                        return nil
+                    }
+                },
+                NewAcquireLock: func(t *testing.T) locker.Acquire {
+                    return func(ctx context.Context, lockID string) mo.Result[bool] {
+                        assert.Equal(t, "usecase:analyze:2025-01-10", lockID)
+                        return mo.Ok(true)
+                    }
+                },
+                NewReleaseLock: func(t *testing.T) locker.Release {
+                    return func(ctx context.Context, lockID string) error {
+                        assert.Equal(t, "usecase:analyze:2025-01-10", lockID)
+                        return nil
+                    }
+                },
+                ctx: appctx.SetNow(context.Background(), time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC)),
+                input: &usecase.AnalyzeInput{
+                    Goal: model.GoalTypeRecentWeek,
+                },
+            },
+            mo.Ok(&usecase.AnalyzeOutput{
+                IsGoalAchieved: true,
+            }),
+        },
+        {
+            "return results of not achieving goal",
+            args{
+                NewFetchLatest: func(t *testing.T) fetcher.FetchLatest {
+                    return func(ctx context.Context) mo.Result[mo.Option[*model.Entry]] {
+                        return mo.Ok(mo.None[*model.Entry]())
+                    }
+                },
+                NewPrintAnalysisReport: func(t *testing.T) printer.PrintAnalysisReport {
+                    return func(report *model.AnalysisReport) error {
+                        assert.Equal(t, &model.AnalysisReport{
+                            IsGoalAchieved: false,
+                            LatestEntry:    mo.None[*model.Entry](),
+                        }, report)
 
-						return nil
-					}
-				},
-				NewAcquireLock: func(t *testing.T) locker.Acquire {
-					return func(ctx context.Context, lockID string) mo.Result[bool] {
-						assert.Equal(t, "usecase:analyze:2025-01-10", lockID)
-						return mo.Ok(true)
-					}
-				},
-				NewReleaseLock: func(t *testing.T) locker.Release {
-					return func(ctx context.Context, lockID string) error {
-						assert.Equal(t, "usecase:analyze:2025-01-10", lockID)
-						return nil
-					}
-				},
-				ctx: appctx.SetNow(context.Background(), time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC)),
-				input: &usecase.AnalyzeInput{
-					Goal: model.GoalTypeRecentWeek,
-				},
-			},
-			mo.Ok(&usecase.AnalyzeOutput{
-				IsGoalAchieved: false,
-			}),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := NewAnalyze(
-				tt.args.NewFetchLatest(t),
-				tt.args.NewPrintAnalysisReport(t),
-				tt.args.NewAcquireLock(t),
-				tt.args.NewReleaseLock(t),
-			)(
-				tt.args.ctx, tt.args.input,
-			)
-			assert.Equal(t, tt.want, got)
-		})
-	}
+                        return nil
+                    }
+                },
+                NewNotify: func(t *testing.T) notifier.NotifyByIsGoalAchieved {
+                    return func(ctx context.Context, isGoalAchieved bool) error {
+                        assert.False(t, isGoalAchieved)
+                        return nil
+                    }
+                },
+                NewAcquireLock: func(t *testing.T) locker.Acquire {
+                    return func(ctx context.Context, lockID string) mo.Result[bool] {
+                        assert.Equal(t, "usecase:analyze:2025-01-10", lockID)
+                        return mo.Ok(true)
+                    }
+                },
+                NewReleaseLock: func(t *testing.T) locker.Release {
+                    return func(ctx context.Context, lockID string) error {
+                        assert.Equal(t, "usecase:analyze:2025-01-10", lockID)
+                        return nil
+                    }
+                },
+                ctx: appctx.SetNow(context.Background(), time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC)),
+                input: &usecase.AnalyzeInput{
+                    Goal: model.GoalTypeRecentWeek,
+                },
+            },
+            mo.Ok(&usecase.AnalyzeOutput{
+                IsGoalAchieved: false,
+            }),
+        },
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got := NewAnalyze(
+                tt.args.NewFetchLatest(t),
+                tt.args.NewPrintAnalysisReport(t),
+                tt.args.NewNotify(t),
+                tt.args.NewAcquireLock(t),
+                tt.args.NewReleaseLock(t),
+            )(
+                tt.args.ctx, tt.args.input,
+            )
+            assert.Equal(t, tt.want, got)
+        })
+    }
 }


### PR DESCRIPTION
Codex による実装。
プロンプトは以下の通り。

```
あなたは熟練したソフトウェアエンジニアです。
以下のタスクを行ってください。

# タスク概要
既存の Haskell 製マイクロサービス（約 100 行）を、既存の Go 製マイクロサービス（約 1000 行）の内部機能へ移行してください。
移行対象コードは「移行前アプリケーション」と呼び、統合先を「移行後アプリケーション」と呼びます。

# 要件
 1. 機能保持: 移行前アプリケーションのビジネスロジック・API 振る舞いを Go 実装に正確に再現してください。
 2. Go の慣習順守: Go の標準的な命名規則・エラーハンドリング・構造体設計を採用してください。
 3. 統合場所: 移行後アプリケーションの既存アーキテクチャに適切に組み込んでください（例: `internal/` 以下にパッケージ追加、サービスレイヤーに統合など）。
 4. 型・エラーハンドリング: Haskell の強力な型システムや `Either`/`Maybe` を、Go では `error` 型や `struct` による表現に落とし込んでください。
 5. テスト: 移行前アプリケーションのテストケースを参考に、Go の `testing` パッケージでユニットテストを書いてください。
 
# アプリケーションコード
- 移行前アプリケーション: ./app/notifier
- 移行後アプリケーション: ./app/analyzer
```