### PR TITLE
feat(analyzer/notifier): Haskell 製 notifier を統合し Slack Webhook 通知を追加

### DIFF
--- a/app/analyzer/internal/adapter/controller/cli/cli.go
+++ b/app/analyzer/internal/adapter/controller/cli/cli.go
@@ -1,16 +1,17 @@
 package cli
 
 import (
-	"context"
+    "context"
 
-	"github.com/samber/lo"
-	"github.com/ss49919201/keeput/app/analyzer/internal/adapter/fetcher/hatena"
-	"github.com/ss49919201/keeput/app/analyzer/internal/adapter/fetcher/zenn"
-	"github.com/ss49919201/keeput/app/analyzer/internal/adapter/locker/cfworker"
-	"github.com/ss49919201/keeput/app/analyzer/internal/adapter/printer/stdout"
-	"github.com/ss49919201/keeput/app/analyzer/internal/model"
-	usecaseport "github.com/ss49919201/keeput/app/analyzer/internal/port/usecase"
-	usecaseadapter "github.com/ss49919201/keeput/app/analyzer/internal/usecase"
+    "github.com/samber/lo"
+    "github.com/ss49919201/keeput/app/analyzer/internal/adapter/fetcher/hatena"
+    "github.com/ss49919201/keeput/app/analyzer/internal/adapter/fetcher/zenn"
+    "github.com/ss49919201/keeput/app/analyzer/internal/adapter/locker/cfworker"
+    notifierslack "github.com/ss49919201/keeput/app/analyzer/internal/adapter/notifier/slack"
+    "github.com/ss49919201/keeput/app/analyzer/internal/adapter/printer/stdout"
+    "github.com/ss49919201/keeput/app/analyzer/internal/model"
+    usecaseport "github.com/ss49919201/keeput/app/analyzer/internal/port/usecase"
+    usecaseadapter "github.com/ss49919201/keeput/app/analyzer/internal/usecase"
 )
 
 func Analyze(ctx context.Context) error {
@@ -26,12 +27,13 @@ func Analyze(ctx context.Context) error {
 		entryPlatformType == model.EntryPlatformTypeZenn, zenn.NewFetchLatest(),
 	).Else(hatena.NewFetchLatest())
 
-	result := usecaseadapter.NewAnalyze(
-		fetcher,
-		stdout.PrintAnalysisReport,
-		cfworker.NewAcquire(),
-		cfworker.NewRelease(),
-	)(ctx, &usecaseport.AnalyzeInput{})
+    result := usecaseadapter.NewAnalyze(
+        fetcher,
+        stdout.PrintAnalysisReport,
+        notifierslack.NewNotify(),
+        cfworker.NewAcquire(),
+        cfworker.NewRelease(),
+    )(ctx, &usecaseport.AnalyzeInput{})
 	if result.IsError() {
 		return result.Error()
 	}

--- a/app/analyzer/internal/adapter/notifier/slack/slack.go
+++ b/app/analyzer/internal/adapter/notifier/slack/slack.go
@@ -1,0 +1,67 @@
+package slack
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "fmt"
+    "io"
+    "log/slog"
+    "net/http"
+    "sync"
+
+    "github.com/hashicorp/go-retryablehttp"
+    "github.com/ss49919201/keeput/app/analyzer/internal/config"
+    "github.com/ss49919201/keeput/app/analyzer/internal/model"
+    "github.com/ss49919201/keeput/app/analyzer/internal/port/notifier"
+    "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+var httpClient = sync.OnceValue(func() *http.Client {
+    client := retryablehttp.NewClient()
+    client.RetryMax = 3
+    client.Logger = slog.Default()
+
+    std := client.StandardClient()
+    std.Transport = otelhttp.NewTransport(std.Transport)
+    return std
+})
+
+type slackReqBody struct {
+    Text string `json:"text"`
+}
+
+// NewNotify builds a notifier.Notify that posts to Slack Incoming Webhook.
+// It uses SLACK_WEBHOOK_URL from environment via config.
+func NewNotify() notifier.Notify {
+    return func(ctx context.Context, report *model.AnalysisReport) error {
+        url := config.SlackWebhookURL()
+        if url == "" {
+            return fmt.Errorf("SLACK_WEBHOOK_URL is empty")
+        }
+        msg := "目標未達です😢これから頑張りましょう！"
+        if report.IsGoalAchieved {
+            msg = "目標達成です🎊よく頑張りました！"
+        }
+        body := slackReqBody{Text: msg}
+        b, err := json.Marshal(body)
+        if err != nil {
+            return err
+        }
+        req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(b))
+        if err != nil {
+            return err
+        }
+        req.Header.Set("Content-Type", "application/json")
+        resp, err := httpClient().Do(req)
+        if err != nil {
+            return err
+        }
+        defer resp.Body.Close()
+        if resp.StatusCode != http.StatusOK {
+            rb, _ := io.ReadAll(resp.Body)
+            return fmt.Errorf("slack webhook unexpected status code %d, body %s", resp.StatusCode, string(rb))
+        }
+        return nil
+    }
+}

--- a/app/analyzer/internal/config/config.go
+++ b/app/analyzer/internal/config/config.go
@@ -30,9 +30,17 @@ func LogLevel() string {
 }
 
 var lockerURLCloudflareWorker = sync.OnceValue(func() string {
-	return os.Getenv("LOCKER_URL_CLOUDFLARE_WORKER")
+    return os.Getenv("LOCKER_URL_CLOUDFLARE_WORKER")
 })
 
 func LockerURLCloudflareWorker() string {
-	return lockerURLCloudflareWorker()
+    return lockerURLCloudflareWorker()
+}
+
+var slackWebhookURL = sync.OnceValue(func() string {
+    return os.Getenv("SLACK_WEBHOOK_URL")
+})
+
+func SlackWebhookURL() string {
+    return slackWebhookURL()
 }

--- a/app/analyzer/internal/port/notifier/notify.go
+++ b/app/analyzer/internal/port/notifier/notify.go
@@ -1,0 +1,12 @@
+package notifier
+
+import (
+    "context"
+
+    "github.com/ss49919201/keeput/app/analyzer/internal/model"
+)
+
+// Notify sends a notification based on the analysis report.
+// Implementations may ignore some fields or use just IsGoalAchieved.
+type Notify = func(ctx context.Context, report *model.AnalysisReport) error
+

--- a/app/analyzer/internal/usecase/analyze.go
+++ b/app/analyzer/internal/usecase/analyze.go
@@ -1,30 +1,31 @@
 package usecase
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"log/slog"
-	"time"
+    "context"
+    "errors"
+    "fmt"
+    "log/slog"
+    "time"
 
-	"github.com/samber/mo"
-	"github.com/ss49919201/keeput/app/analyzer/internal/appctx"
-	"github.com/ss49919201/keeput/app/analyzer/internal/model"
-	"github.com/ss49919201/keeput/app/analyzer/internal/port/fetcher"
-	"github.com/ss49919201/keeput/app/analyzer/internal/port/locker"
-	"github.com/ss49919201/keeput/app/analyzer/internal/port/printer"
-	"github.com/ss49919201/keeput/app/analyzer/internal/port/usecase"
+    "github.com/samber/mo"
+    "github.com/ss49919201/keeput/app/analyzer/internal/appctx"
+    "github.com/ss49919201/keeput/app/analyzer/internal/model"
+    "github.com/ss49919201/keeput/app/analyzer/internal/port/fetcher"
+    "github.com/ss49919201/keeput/app/analyzer/internal/port/locker"
+    "github.com/ss49919201/keeput/app/analyzer/internal/port/printer"
+    "github.com/ss49919201/keeput/app/analyzer/internal/port/notifier"
+    "github.com/ss49919201/keeput/app/analyzer/internal/port/usecase"
 )
 
-func NewAnalyze(fetchAllByDate fetcher.FetchLatest, printAnalysisReport printer.PrintAnalysisReport, acquireLock locker.Acquire, releaseLock locker.Release) usecase.Analyze {
-	return func(ctx context.Context, in *usecase.AnalyzeInput) mo.Result[*usecase.AnalyzeOutput] {
-		return analyze(ctx, in, fetchAllByDate, printAnalysisReport, acquireLock, releaseLock)
-	}
+func NewAnalyze(fetchAllByDate fetcher.FetchLatest, printAnalysisReport printer.PrintAnalysisReport, notify notifier.Notify, acquireLock locker.Acquire, releaseLock locker.Release) usecase.Analyze {
+    return func(ctx context.Context, in *usecase.AnalyzeInput) mo.Result[*usecase.AnalyzeOutput] {
+        return analyze(ctx, in, fetchAllByDate, printAnalysisReport, notify, acquireLock, releaseLock)
+    }
 }
 
 const lockIDPrefixAnalyze = "usecase:analyze"
 
-func analyze(ctx context.Context, in *usecase.AnalyzeInput, fetchLatest fetcher.FetchLatest, printAnalysisReport printer.PrintAnalysisReport, acquireLock locker.Acquire, releaseLock locker.Release) mo.Result[*usecase.AnalyzeOutput] {
+func analyze(ctx context.Context, in *usecase.AnalyzeInput, fetchLatest fetcher.FetchLatest, printAnalysisReport printer.PrintAnalysisReport, notify notifier.Notify, acquireLock locker.Acquire, releaseLock locker.Release) mo.Result[*usecase.AnalyzeOutput] {
 	lockID := lockIDPrefixAnalyze + ":" + appctx.GetNowOr(ctx, time.Now()).Format(time.DateOnly)
 	acquireLockResult := acquireLock(ctx, lockID)
 	if acquireLockResult.IsError() {
@@ -44,13 +45,18 @@ func analyze(ctx context.Context, in *usecase.AnalyzeInput, fetchLatest fetcher.
 		return mo.Err[*usecase.AnalyzeOutput](fmt.Errorf("failed to fetch latest entry: %w", err))
 	}
 
-	report := model.Analyze(latestEntry, appctx.GetNowOr(ctx, time.Now()), in.Goal)
+    report := model.Analyze(latestEntry, appctx.GetNowOr(ctx, time.Now()), in.Goal)
 
-	if err := printAnalysisReport(report); err != nil {
-		return mo.Err[*usecase.AnalyzeOutput](fmt.Errorf("failed to print anlysis report: %w", err))
-	}
+    if err := printAnalysisReport(report); err != nil {
+        return mo.Err[*usecase.AnalyzeOutput](fmt.Errorf("failed to print anlysis report: %w", err))
+    }
 
-	return mo.Ok(&usecase.AnalyzeOutput{
-		IsGoalAchieved: report.IsGoalAchieved,
-	})
+    // Notify result. Keep non-fatal: log warning on failure but do not interrupt usecase.
+    if err := notify(ctx, report); err != nil {
+        slog.Warn("failed to notify analysis result", slog.String("error", err.Error()))
+    }
+
+    return mo.Ok(&usecase.AnalyzeOutput{
+        IsGoalAchieved: report.IsGoalAchieved,
+    })
 }


### PR DESCRIPTION
Codex による実装。
プロンプトは以下の通り。

```
あなたは熟練したソフトウェアエンジニアです。
以下のタスクを行ってください。

# タスク概要
既存の Haskell 製マイクロサービス（約 100 行）を、既存の Go 製マイクロサービス（約 1000 行）の内部機能へ移行してください。
移行対象コードは「移行前アプリケーション」と呼び、統合先を「移行後アプリケーション」と呼びます。

# 要件
 1. 機能保持: 移行前アプリケーションのビジネスロジック・API 振る舞いを Go 実装に正確に再現してください。
 2. 統合場所: 移行後アプリケーションの既存アーキテクチャに適切に組み込んでください（例: `internal/` 以下にパッケージ追加、サービスレイヤーに統合など）。
 3. コードの命名規則やモジュール設計、ログ、エラーハンドリング、計装、コメントの書き方は移行後アプリケーションを参考に設計してください。
 
# アプリケーションコード
- 移行前アプリケーション: ./app/notifier
- 移行後アプリケーション: ./app/analyzer
```