### PR TITLE
locker へのアクセス時の処理のリファクタリング

### DIFF
--- a/app/analyzer/internal/adapter/fetcher/internal/fetcher.go
+++ b/app/analyzer/internal/adapter/fetcher/internal/fetcher.go
@@ -2,29 +2,19 @@ package internal
 
 import (
 	"context"
-	"log/slog"
 	"net/http"
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/mmcdole/gofeed"
 	"github.com/samber/lo"
 	"github.com/samber/mo"
+	"github.com/ss49919201/keeput/app/analyzer/internal/apphttp"
 	"github.com/ss49919201/keeput/app/analyzer/internal/model"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 var httpClient = sync.OnceValue(func() *http.Client {
-	// NOTE: retryablehttp.NewClient() は内部で cleanhttp.DefaultPooledClient() を使う。
-	// cleanhttp.DefaultPooledClient() が返す http.Client にはタイムアウトが設定されている。
-	client := retryablehttp.NewClient()
-	client.RetryMax = 3
-	client.Logger = slog.Default()
-
-	standAloneClient := client.StandardClient()
-	standAloneClient.Transport = otelhttp.NewTransport(standAloneClient.Transport)
-	return standAloneClient
+	return apphttp.DefaultClient()
 })
 
 // NOTE: 公開日が存在しないエントリは除外する。

--- a/app/analyzer/internal/adapter/locker/cfworker/locker.go
+++ b/app/analyzer/internal/adapter/locker/cfworker/locker.go
@@ -7,16 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"sync"
 
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/samber/mo"
+	"github.com/ss49919201/keeput/app/analyzer/internal/apphttp"
 	"github.com/ss49919201/keeput/app/analyzer/internal/config"
 	"github.com/ss49919201/keeput/app/analyzer/internal/port/locker"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 const (
@@ -24,15 +22,7 @@ const (
 )
 
 var httpClient = sync.OnceValue(func() *http.Client {
-	// NOTE: retryablehttp.NewClient() は内部で cleanhttp.DefaultPooledClient() を使う。
-	// cleanhttp.DefaultPooledClient() が返す http.Client にはタイムアウトが設定されている。
-	client := retryablehttp.NewClient()
-	client.RetryMax = 3
-	client.Logger = slog.Default()
-
-	standAloneClient := client.StandardClient()
-	standAloneClient.Transport = otelhttp.NewTransport(standAloneClient.Transport)
-	return standAloneClient
+	return apphttp.DefaultClient()
 })
 
 func NewAcquire() locker.Acquire {

--- a/app/analyzer/internal/adapter/locker/cfworker/locker.go
+++ b/app/analyzer/internal/adapter/locker/cfworker/locker.go
@@ -19,6 +19,10 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
+const (
+	headerKeyLockerAPIKey = "X-LOCKER-API-KEY"
+)
+
 var httpClient = sync.OnceValue(func() *http.Client {
 	// NOTE: retryablehttp.NewClient() は内部で cleanhttp.DefaultPooledClient() を使う。
 	// cleanhttp.DefaultPooledClient() が返す http.Client にはタイムアウトが設定されている。
@@ -63,7 +67,7 @@ func acquire(ctx context.Context, lockID string) mo.Result[bool] {
 		return mo.Err[bool](err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-LOCKER-API-KEY", config.LockerAPIKeyCloudflareWorker())
+	req.Header.Set(headerKeyLockerAPIKey, config.LockerAPIKeyCloudflareWorker())
 	resp, err := httpClient().Do(req)
 	if err != nil {
 		return mo.Err[bool](err)
@@ -115,7 +119,7 @@ func release(ctx context.Context, lockID string) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-LOCKER-API-KEY", config.LockerAPIKeyCloudflareWorker())
+	req.Header.Set(headerKeyLockerAPIKey, config.LockerAPIKeyCloudflareWorker())
 	resp, err := httpClient().Do(req)
 	if err != nil {
 		return err

--- a/app/analyzer/internal/adapter/locker/cfworker/locker.go
+++ b/app/analyzer/internal/adapter/locker/cfworker/locker.go
@@ -86,15 +86,19 @@ func NewRelease() locker.Release {
 	}
 }
 
+type releaseRequest struct {
+	LockID string `json:"lockId"`
+}
+
 type releaseResponse struct {
 	Msg string `json:"msg"`
 }
 
 func release(ctx context.Context, lockID string) error {
-	reqBodyMap := map[string]string{
-		"lockId": lockID,
+	reqBody := releaseRequest{
+		LockID: lockID,
 	}
-	reqBodyBytes, err := json.Marshal(reqBodyMap)
+	reqBodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
 		return err
 	}

--- a/app/analyzer/internal/adapter/locker/cfworker/locker.go
+++ b/app/analyzer/internal/adapter/locker/cfworker/locker.go
@@ -37,16 +37,20 @@ func NewAcquire() locker.Acquire {
 	}
 }
 
+type acquireRequest struct {
+	LockID string `json:"lockId"`
+}
+
 type acquireResponse struct {
 	Msg string `json:"msg"`
 }
 
 // TODO: release との共通部分を抽象化して関数にする。
 func acquire(ctx context.Context, lockID string) mo.Result[bool] {
-	reqBodyMap := map[string]string{
-		"lockId": lockID,
+	reqBody := acquireRequest{
+		LockID: lockID,
 	}
-	reqBodyBytes, err := json.Marshal(reqBodyMap)
+	reqBodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
 		return mo.Err[bool](err)
 	}

--- a/app/analyzer/internal/adapter/notifier/discord/discord.go
+++ b/app/analyzer/internal/adapter/notifier/discord/discord.go
@@ -6,26 +6,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"sync"
 
-	"github.com/hashicorp/go-retryablehttp"
+	"github.com/ss49919201/keeput/app/analyzer/internal/apphttp"
 	"github.com/ss49919201/keeput/app/analyzer/internal/config"
 	"github.com/ss49919201/keeput/app/analyzer/internal/port/notifier"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 var httpClient = sync.OnceValue(func() *http.Client {
-	// NOTE: retryablehttp.NewClient() は内部で cleanhttp.DefaultPooledClient() を使う。
-	// cleanhttp.DefaultPooledClient() が返す http.Client にはタイムアウトが設定されている。
-	client := retryablehttp.NewClient()
-	client.RetryMax = 3
-	client.Logger = slog.Default()
-
-	standAloneClient := client.StandardClient()
-	standAloneClient.Transport = otelhttp.NewTransport(standAloneClient.Transport)
-	return standAloneClient
+	return apphttp.DefaultClient()
 })
 
 type reqBody struct {

--- a/app/analyzer/internal/apphttp/client.go
+++ b/app/analyzer/internal/apphttp/client.go
@@ -1,0 +1,20 @@
+package apphttp
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+func DefaultClient() *http.Client {
+	client := retryablehttp.NewClient()
+	client.RetryMax = 3
+	client.Logger = slog.Default()
+	standAloneClient := client.StandardClient()
+	standAloneClient.Timeout = 30 * time.Second
+	standAloneClient.Transport = otelhttp.NewTransport(standAloneClient.Transport)
+	return standAloneClient
+}


### PR DESCRIPTION
close #30 

- feat(analyzer): lock 解放のリクエストボディ用構造体を定義
- feat(analyzer): lock 取得のリクエストボディ用構造体を定義
- refactor(analyzer): locker API キーのリクエストヘッダーキーを定数化
- feat(analyzer): HTTP クライアント初期化を共通パッケージ化
