### PR TITLE
分析レポートを永続化する

### DIFF
--- a/app/analyzer/internal/adapter/notifier/discord/discord.go
+++ b/app/analyzer/internal/adapter/notifier/discord/discord.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ss49919201/keeput/app/analyzer/internal/apphttp"
 	"github.com/ss49919201/keeput/app/analyzer/internal/config"
+	"github.com/ss49919201/keeput/app/analyzer/internal/model"
 	"github.com/ss49919201/keeput/app/analyzer/internal/port/notifier"
 )
 
@@ -23,13 +24,13 @@ type reqBody struct {
 }
 
 func NewNotifyAnalysisReport() notifier.NotifyAnalysisReport {
-	return func(ctx context.Context, isGoalAchieved bool) error {
-		return notifyAnalysisReport(ctx, config.DiscordWebhookURL(), isGoalAchieved)
+	return func(ctx context.Context, report *model.AnalysisReport) error {
+		return notifyAnalysisReport(ctx, config.DiscordWebhookURL(), report)
 	}
 }
 
-func notifyAnalysisReport(ctx context.Context, webhookURL string, isGoalAchieved bool) error {
-	body := reqBody{Content: message(isGoalAchieved)}
+func notifyAnalysisReport(ctx context.Context, webhookURL string, report *model.AnalysisReport) error {
+	body := reqBody{Content: buildMessage(report)}
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request body: %w", err)
@@ -55,8 +56,8 @@ func notifyAnalysisReport(ctx context.Context, webhookURL string, isGoalAchieved
 	return nil
 }
 
-func message(isGoalAchieved bool) string {
-	if isGoalAchieved {
+func buildMessage(report *model.AnalysisReport) string {
+	if report.IsGoalAchieved {
 		return "目標達成です🎊よく頑張りました！"
 	}
 	return "目標未達です😢これから頑張りましょう！"

--- a/app/analyzer/internal/appotel/otel.go
+++ b/app/analyzer/internal/appotel/otel.go
@@ -8,7 +8,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
-	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -28,9 +28,9 @@ func InitTraceProvider(ctx context.Context) (func(context.Context) error, error)
 			errInitOtelProvider = err
 			return
 		}
-		tp := sdkTrace.NewTracerProvider(
-			sdkTrace.WithSyncer(exporter),
-			sdkTrace.WithResource(resource),
+		tp := sdktrace.NewTracerProvider(
+			sdktrace.WithSyncer(exporter),
+			sdktrace.WithResource(resource),
 		)
 		otel.SetTracerProvider(tp)
 		otel.SetTextMapPropagator(propagation.TraceContext{})

--- a/app/analyzer/internal/port/notifier/notifier.go
+++ b/app/analyzer/internal/port/notifier/notifier.go
@@ -1,7 +1,9 @@
 package notifier
 
-import "context"
+import (
+	"context"
 
-// NotifyAnalysisReport sends a notification based on goal achievement.
-// true -> success message, false -> failure message.
-type NotifyAnalysisReport = func(context.Context, bool) error
+	"github.com/ss49919201/keeput/app/analyzer/internal/model"
+)
+
+type NotifyAnalysisReport = func(context.Context, *model.AnalysisReport) error

--- a/app/analyzer/internal/usecase/analyze.go
+++ b/app/analyzer/internal/usecase/analyze.go
@@ -51,7 +51,7 @@ func analyze(ctx context.Context, in *usecase.AnalyzeInput, fetchLatest fetcher.
 		return mo.Err[*usecase.AnalyzeOutput](fmt.Errorf("failed to print anlysis report: %w", err))
 	}
 
-	if err := notify(ctx, report.IsGoalAchieved); err != nil {
+	if err := notify(ctx, report); err != nil {
 		slog.Warn("failed to notify", "error", err)
 	}
 

--- a/app/analyzer/internal/usecase/analyze_test.go
+++ b/app/analyzer/internal/usecase/analyze_test.go
@@ -59,8 +59,15 @@ func TestAnalyze(t *testing.T) {
 					}
 				},
 				NewNotify: func(t *testing.T) notifier.NotifyAnalysisReport {
-					return func(ctx context.Context, isGoalAchieved bool) error {
-						assert.True(t, isGoalAchieved)
+					return func(ctx context.Context, report *model.AnalysisReport) error {
+						assert.Equal(t, &model.AnalysisReport{
+							IsGoalAchieved: true,
+							LatestEntry: mo.Some(&model.Entry{
+								Title:       "Go 言語の slice について",
+								Body:        "Go 言語の slice は参照型です。気をつけましょう。",
+								PublishedAt: time.Date(2025, 1, 9, 10, 0, 0, 0, time.UTC),
+							}),
+						}, report)
 						return nil
 					}
 				},
@@ -104,8 +111,11 @@ func TestAnalyze(t *testing.T) {
 					}
 				},
 				NewNotify: func(t *testing.T) notifier.NotifyAnalysisReport {
-					return func(ctx context.Context, isGoalAchieved bool) error {
-						assert.False(t, isGoalAchieved)
+					return func(ctx context.Context, report *model.AnalysisReport) error {
+						assert.Equal(t, &model.AnalysisReport{
+							IsGoalAchieved: false,
+							LatestEntry:    mo.None[*model.Entry](),
+						}, report)
 						return nil
 					}
 				},


### PR DESCRIPTION
- refactor(analyzer): 名前付き import を変更
- refactor(analyzer): 通知ポートのインタフェースを変更
